### PR TITLE
Update to v1.1142.0; rename sbom command to client-sbom

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Build and Release
 on:
   - push
 env:
-  SNYK_VERSION: "1.1128.0"
+  SNYK_VERSION: "1.1142.0"
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -16,8 +16,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: "18.x"
-      - name: apply patch adding the sbom creation feature
-        run: curl --fail -Ls "https://github.com/candrews/snyk-cli/commit/da20e6fd5f47322278b52dad61d3069668828f02.patch" | git apply
+      - name: apply patch adding the client-sbom creation feature
+        run: curl --fail -Ls "https://github.com/candrews/snyk-cli/commit/4e13f3890b0da841e68762562cb6f0b363b39cde.patch" | git apply
       - name: Install dependencies
         run: npm ci
       - name: make pre-build

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # `@candrewsintegralblue/snyk`
 
-`@candrewsintegralblue/snyk` is a fork of [`snyk`](https://www.npmjs.com/package/snyk) that adds a new subcommand, `sbom`, that creates an SBOM (Software Bill of Material) of the project being scanned.
+`@candrewsintegralblue/snyk` is a fork of [`snyk`](https://www.npmjs.com/package/snyk) that adds a new subcommand, `client-sbom`, that creates an SBOM (Software Bill of Material) of the project being scanned entirely client side - there is no communication with the Snyk API, therefore no Snyk credentials are required and no network access is required.
 
 [The SBOM creation feature has been submitted via merge request to Snyk](https://github.com/snyk/cli/pull/3983) for inclusion in the official package, but so far, it hasn't been merged or included in any releases.
 
+[Snyk added an `sbom` command](https://docs.snyk.io/snyk-cli/commands/sbom) in [v1.1071.0](https://github.com/snyk/cli/releases/tag/v1.1071.0). However, this command generates the sbom on the Snyk server and requires an Enterprise plan to use. Therefore, this client side approach to generating the sbom is still valuable.
+
 For background on why this improvement is a very useful enhancement to Snyk, see [Creating SBOMs with the Snyk CLI](https://candrews.integralblue.com/2022/10/creating-sboms-with-the-snyk-cli/).
 
-For more information on how to use this feature, see the built in help: `npx @candrewsintegralblue/snyk sbom --help`
+For more information on how to use this feature, see the built in help: `npx @candrewsintegralblue/snyk client-sbom --help`


### PR DESCRIPTION
Snyk added an sbom command in v1.1071.0. However, this command generates the sbom on the Snyk server and requires an Enterprise plan to use. Therefore, this client side approach to generating the sbom is still valuable.

See: https://docs.snyk.io/snyk-cli/commands/sbom

See: https://github.com/snyk/cli/releases/tag/v1.1071.0