### PR TITLE
Set TERM="xterm" when running unit tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
         env:
           SNYK_TOKEN: "123456789"  # Some tests require a token to be set. Most don't actually use it: https://github.com/snyk/cli/issues/4200 But, at least one ("succeed testing with correct exit code - and analytics added" in test/jest/unit/snyk-code/snyk-code-test.spec.ts) requires it to be set to "123456789"
           FORCE_COLOR: "1"  # Some tests check for ANSI color codes. chalk doesn't enable color by default for the terminal settings used by GitHub Actions, so color must be forced.
+          TERM: "xterm" # The TERM value used by GitHub results in different behavior than TERM="xterm" which is what Snyk upstream uses to run tests, causing false tests failures.
       - name: prepack
         run: npx ts-node ./release-scripts/prune-dependencies-in-packagejson.ts
       - name: set package name to @candrewsintegralblue/snyk


### PR DESCRIPTION
The TERM value used by GitHub results in different behavior than TERM="xterm" which is what Snyk upstream uses to run tests resulting in false tests failures.